### PR TITLE
Use offset to find client date

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -16,3 +16,5 @@ es5-shim                # ECMAScript 5 compatibility for older browsers.
 ecmascript              # Enable ECMAScript2015+ syntax in app code
 
 autopublish             # Publish all data to the clients (for prototyping)
+momentjs:moment         # A lightweight JavaScript date library for parsing, validating, manipulating, and formatting dates.
+mizzao:timesync         # NTP-style time synchronization between server and client

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -37,8 +37,10 @@ meteor@1.1.10
 meteor-base@1.0.1
 minifiers@1.1.7
 minimongo@1.0.10
+mizzao:timesync@0.3.4
 mobile-experience@1.0.1
 mobile-status-bar@1.0.6
+momentjs:moment@2.13.1
 mongo@1.1.3
 mongo-id@1.0.1
 npm-mongo@1.4.39_1

--- a/justgrimes-review.js
+++ b/justgrimes-review.js
@@ -23,7 +23,8 @@ if (Meteor.isClient) {
           input.disabled = true;
           if (input.checked) {
             var rating = parseInt(input.value, 10);
-            Meteor.call('addRating', rating);
+            var offset = TimeSync.serverOffset();
+            Meteor.call('addRating', rating, offset);
 
             [].slice.call(e.target.getElementsByTagName('label'))
               .forEach(function (label, j) {
@@ -44,10 +45,9 @@ if (Meteor.isClient) {
 }
 
 Meteor.methods({
-  addRating: function (rating) {
+  addRating: function (rating, offset) {
     if (rating > 0 && rating <= 5) {
-      var d = new Date();
-      var today = [d.getUTCFullYear(), zeropad(d.getUTCMonth() + 1, 2), zeropad(d.getUTCDate(), 2)].join('-');
+      var today = moment().add(offset, 'milliseconds').format('YYYY-MM-DD');
       Days.upsert(
         { date: today },
         {

--- a/justgrimes-review.js
+++ b/justgrimes-review.js
@@ -33,7 +33,7 @@ if (Meteor.isClient) {
                     label.className = 'spin';
                   }, j * 50);
                 }
-              })
+              });
           }
         });
     },
@@ -41,12 +41,12 @@ if (Meteor.isClient) {
       document.getElementById('rating').className = 'active';
       document.getElementById('submit').disabled = false;
     }
-  })
+  });
 }
 
 Meteor.methods({
   addRating: function (rating, offset) {
-    if (rating > 0 && rating <= 5) {
+    if ((rating > 0 && rating <= 5) && ((-12 * 60 * 60 * 1000) <= offset && offset <= (14 * 60 * 60 * 1000))) {
       var today = moment().add(offset, 'milliseconds').format('YYYY-MM-DD');
       Days.upsert(
         { date: today },


### PR DESCRIPTION
I'm not quite sure how to test it, but this uses `timesync` to find the offset in milliseconds between the client and server, then uses `moment` to add/subtract that from the server time before upserting the rating. That should have the effect of using the client time in the database instead of the server time.
